### PR TITLE
fix: skip duplicate IDs in ownedTokenIds

### DIFF
--- a/contracts/genesisKey/GenesisKeyTeamClaim.sol
+++ b/contracts/genesisKey/GenesisKeyTeamClaim.sol
@@ -74,15 +74,24 @@ contract GenesisKeyTeamClaim is Initializable, UUPSUpgradeable {
         // effects
         // interactions
         if (ownedTokenIds.length != 0) {
+            while (GK.ownerOf(ownedTokenIds[0]) != address(this)) {
+                if (ownedTokenIds.length > 1) {
+                    ownedTokenIds[0] = ownedTokenIds[ownedTokenIds.length - 1];
+                }
+                ownedTokenIds.pop();
+            }
+            if (ownedTokenIds.length == 0) {
+                return false;
+            }
+
             GK.transferFrom(address(this), recipient, ownedTokenIds[0]);
+            emit ClaimedGenesisKey(recipient, 0, block.number, true);
 
             if (ownedTokenIds.length > 1) {
                 ownedTokenIds[0] = ownedTokenIds[ownedTokenIds.length - 1];
             }
-
             ownedTokenIds.pop();
 
-            emit ClaimedGenesisKey(recipient, 0, block.number, true);
             return true;
         }
 


### PR DESCRIPTION
if an ID is duplicated in this array, we want to skip the second occurence.

steps to do this:
- check if the "next" token ID is still owned by the contract.
- if it is, use the same old logic
- if not, continue to the subsequent ID until the "next" is owned by the contract